### PR TITLE
Fix spectrum analysis generation

### DIFF
--- a/workdir/a3_doc_xtags.py
+++ b/workdir/a3_doc_xtags.py
@@ -43,9 +43,11 @@ def register_tags():
                 tag = opereration["tags"][0]
                 cat = tag.split(" ")[0].strip()
                 if cat in out:
-                    if not tag in out[cat]:
-                        if not next(item for item in TAGS if item["name"] == tag):
-                            print(f"MISSING TAG: {tag}")
+                    if tag not in out[cat]:
+                        if not any(item["name"] == tag for item in TAGS):
+                            print(
+                                f"[INFO] Missing tag definition: '{tag}' (path='{path}', verb='{verb}', cat='{cat}')"
+                            )
                         out[cat].append(tag)
                 else:
                     print(f"Missing tag group for {tag}")

--- a/workdir/openapi.yaml
+++ b/workdir/openapi.yaml
@@ -23133,7 +23133,7 @@ paths:
   /api/v1/sites/{site_id}/analyze_spectrum:
     get:
       description: Get the running spectrum analysis for a site
-      operationId: getSiteRunningSprectrumAnalysis
+      operationId: getSiteRunningSpectrumAnalysis
       responses:
         '200':
           $ref: '#/components/responses/RunningSpectrumAnalysis'
@@ -23147,9 +23147,9 @@ paths:
           $ref: '#/components/responses/HTTP404'
         '429':
           $ref: '#/components/responses/HTTP429'
-      summary: getSiteRunningSprectrumAnalysis
+      summary: getSiteRunningSpectrumAnalysis
       tags:
-      - Sites Sprectrum Analysis
+      - Sites Spectrum Analysis
     parameters:
     - $ref: '#/components/parameters/site_id'
     post:
@@ -23195,7 +23195,7 @@ paths:
           $ref: '#/components/responses/HTTP429'
       summary: initiateSiteAnalyzeSpectrum
       tags:
-      - Sites Sprectrum Analysis
+      - Sites Spectrum Analysis
   /api/v1/sites/{site_id}/anomaly/client/{client_mac}/{metric}:
     get:
       description: Get Client Anomaly Events
@@ -33623,7 +33623,7 @@ paths:
           $ref: '#/components/responses/HTTP429'
       summary: listSiteSpectrumAnalysis
       tags:
-      - Sites Sprectrum Analysis
+      - Sites Spectrum Analysis
     parameters:
     - $ref: '#/components/parameters/site_id'
   /api/v1/sites/{site_id}/stats/apps/count:


### PR DESCRIPTION
1. Fix Sites Spectrum Analysis tag
2. Improve logging if missing tag defs detected e.g. above.
